### PR TITLE
Add tests for POST and PUT requests, create helper methods for requests

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-API_KEY:special-key
+API_KEY:

--- a/test-data/pets.json
+++ b/test-data/pets.json
@@ -8,7 +8,7 @@
     },
     "name": "Loki",
     "photoUrls": [
-      "string"
+      "https://www.petsonme.com.au/wp-content/uploads/2023/08/image-3.jpeg"
     ],
     "tags": [
       {
@@ -24,14 +24,15 @@
 },
 
 {
-    "id": 156,
+    "id": 155,
     "category": {
       "id": 7,
       "name": "German Shepherd"
     },
     "name": "Luna",
     "photoUrls": [
-      "string"
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/German_Shepherd_-_DSC_0346_%2810096362833%29.jpg/250px-German_Shepherd_-_DSC_0346_%2810096362833%29.jpg",
+      "https://cdn.britannica.com/79/232779-050-6B0411D7/German-Shepherd-dog-Alsatian.jpg"
     ],
     "tags": [
       {

--- a/tests/API/helpers/api-requests.ts
+++ b/tests/API/helpers/api-requests.ts
@@ -1,0 +1,37 @@
+import { APIRequestContext, APIResponse } from '@playwright/test';
+import { sendRequest } from './request-helper';
+import pets from '../../../test-data/pets.json';
+
+const baseUrl = 'https://petstore.swagger.io/v2/pet';
+const defaultHeaders = {
+  'Accept': 'application/json',
+  'api_key': '',
+};
+const testPet = pets[0];
+const editedPet = pets[1];
+
+export async function createPet(request: APIRequestContext, pet: any): Promise<APIResponse> {
+  return await sendRequest(request, {
+    method: 'POST',
+    url: baseUrl,
+    headers: defaultHeaders,
+    data: testPet,
+  });
+}
+
+export async function getPet(request: APIRequestContext, id: number): Promise<APIResponse> {
+  return await sendRequest(request, {
+    method: 'GET',
+    url: `${baseUrl}/${testPet.id}`,
+    headers: defaultHeaders,
+  });
+}
+
+export async function updatePet(request: APIRequestContext, pet: any): Promise<APIResponse> {
+  return await sendRequest(request, {
+    method: 'PUT',
+    url: baseUrl,
+    headers: defaultHeaders,
+    data: editedPet,
+  });
+}

--- a/tests/API/helpers/request-helper.ts
+++ b/tests/API/helpers/request-helper.ts
@@ -1,0 +1,28 @@
+import { APIRequestContext, APIResponse } from '@playwright/test';
+
+interface RequestOptions {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  url: string;
+  headers?: Record<string, string>;
+  data?: any;
+}
+
+export async function sendRequest(
+  request: APIRequestContext,
+  options: RequestOptions
+): Promise<APIResponse> {
+  const { method, url, headers = {}, data } = options;
+
+  switch (method) {
+    case 'GET':
+      return await request.get(url, { headers });
+    case 'POST':
+      return await request.post(url, { headers, data });
+    case 'PUT':
+      return await request.put(url, { headers, data });
+    case 'DELETE':
+      return await request.delete(url, { headers });
+    default:
+      throw new Error(`Unsupported method: ${method}`);
+  }
+}

--- a/tests/API/pet/get-pet.spec.ts
+++ b/tests/API/pet/get-pet.spec.ts
@@ -1,17 +1,16 @@
 import { test, expect, APIResponse } from '@playwright/test';
+import pets from '../../../test-data/pets.json';
+import { createPet, getPet } from '../helpers/api-requests';
 
 test.describe('Test Endpoint GET /pet/{PetID}', () => {
 
   let response: APIResponse;
   let body: any;
+  const testPet = pets[0];
 
   test.beforeAll(async ({ request }) => {
-    response = await request.get('https://petstore.swagger.io/v2/pet/1', {
-      headers: {
-        'Accept': 'application/json',
-        'api_key': 'testApiKey',
-      },
-    });
+    await createPet(request, testPet);
+    response = await getPet(request, testPet.id);
     body = await response.json();
   });
 

--- a/tests/API/pet/post-pet.spec.ts
+++ b/tests/API/pet/post-pet.spec.ts
@@ -1,17 +1,16 @@
 import { test, expect, APIResponse } from '@playwright/test';
+import pets from '../../../test-data/pets.json'
+import { getPet } from '../helpers/api-requests';
 
-test.describe('Test Endpoint GET /pet/{PetID}', () => {
+test.describe('Test Endpoint POST /pet', () => {
 
   let response: APIResponse;
+  const testPet = pets[0];
   let body: any;
 
+
   test.beforeAll(async ({ request }) => {
-    response = await request.get('https://petstore.swagger.io/v2/pet/15', {
-      headers: {
-        'Accept': 'application/json',
-        'api_key': 'testApiKey',
-      },
-    });
+    response = await getPet(request, testPet.id);
     body = await response.json();
   });
 
@@ -19,33 +18,39 @@ test.describe('Test Endpoint GET /pet/{PetID}', () => {
     expect(response.status()).toBe(200);
   });
 
-  test('should have ID property', async () => {
+  test('should have correct ID', async () => {
     expect(body).toHaveProperty('id');
     expect(typeof body.id).toBe('number');
+    expect(body.id).toBe(testPet.id);
   });
 
-  test('should have a name property', async () => {
+  test('should have correct name', async () => {
     expect(body).toHaveProperty('name');
     expect(typeof body.name).toBe('string');
+    expect(body.name).toBe(testPet.name);
   });
 
-  test('should have a category property', async () => {
+  test('should have correct category', async () => {
     expect(body).toHaveProperty('category');
     expect(typeof body.category).toBe('object');
     expect(body.category).toHaveProperty('id');
+    expect(body.category.id).toBe(testPet.category.id);
     expect(typeof body.category.id).toBe('number');
     expect(body.category).toHaveProperty('name');
+    expect(body.category.name).toBe(testPet.category.name);
     expect(typeof body.category.name).toBe('string');
   });
 
   test('should have a photoUrls property', async () => {
     expect(body).toHaveProperty('photoUrls');
     expect(typeof body.photoUrls).toBe('object');
+    expect(body.photoUrls).toStrictEqual(testPet.photoUrls);
   });
 
-  test('should have a tags property', async () => {
+  test('should have correct tags', async () => {
     expect(body).toHaveProperty('tags');
     expect(typeof body.tags).toBe('object');
+    expect(body.tags).toEqual(testPet.tags);
 
     for (const tag of body.tags) {
       expect(typeof tag).toBe('object');
@@ -58,9 +63,10 @@ test.describe('Test Endpoint GET /pet/{PetID}', () => {
 
   });
 
-  test('should have a status property', async () => {
+  test('should have correct status', async () => {
     expect(body).toHaveProperty('status');
     expect(typeof body.status).toBe('string');
+    expect(body.status).toEqual(testPet.status);
   });
 
 });

--- a/tests/API/pet/put-pet.spec.ts
+++ b/tests/API/pet/put-pet.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, APIResponse } from '@playwright/test';
+import pets from '../../../test-data/pets.json';
+import { createPet, updatePet } from '../helpers/api-requests';
+
+test.describe('Test Endpoint PUT /pet', () => {
+
+  let response: APIResponse;
+  let body: any;
+  const testPet = pets[0];
+  const editedPet = pets[1];
+
+  test.beforeAll(async ({ request }) => {
+    await createPet(request, testPet);
+    response = await updatePet(request, editedPet);
+    body = await response.json();
+  });
+
+  test('should return 200 status', async () => {
+    expect(response.status()).toBe(200);
+  });
+
+  test('should edit the correct ID', async () => {
+    expect(body).toHaveProperty('id');
+    expect(typeof body.id).toBe('number');
+    expect(body.id).toBe(editedPet.id);
+  });
+
+  test('should edit the correct name', async () => {
+    expect(body).toHaveProperty('name');
+    expect(typeof body.name).toBe('string');
+    expect(body.name).toBe(editedPet.name);
+  });
+
+  test('should edit the correct category', async () => {
+    expect(body).toHaveProperty('category');
+    expect(typeof body.category).toBe('object');
+    expect(body.category).toHaveProperty('id');
+    expect(body.category.id).toBe(editedPet.category.id);
+    expect(typeof body.category.id).toBe('number');
+    expect(body.category).toHaveProperty('name');
+    expect(body.category.name).toBe(editedPet.category.name);
+    expect(typeof body.category.name).toBe('string');
+  });
+
+  test('should edit the a photoUrls property', async () => {
+    expect(body).toHaveProperty('photoUrls');
+    expect(typeof body.photoUrls).toBe('object');
+    expect(body.photoUrls).toStrictEqual(editedPet.photoUrls);
+  });
+
+  test('should edit the correct tags', async () => {
+    expect(body).toHaveProperty('tags');
+    expect(typeof body.tags).toBe('object');
+    expect(body.tags).toEqual(editedPet.tags);
+
+    for (const tag of body.tags) {
+      expect(typeof tag).toBe('object');
+      expect(tag).not.toBeNull();
+      expect(tag).toHaveProperty('id');
+      expect(typeof tag.id).toBe('number');
+      expect(tag).toHaveProperty('name');
+      expect(typeof tag.name).toBe('string');
+    }
+
+  });
+
+  test('should edit the correct status', async () => {
+    expect(body).toHaveProperty('status');
+    expect(typeof body.status).toBe('string');
+    expect(body.status).toEqual(editedPet.status);
+  });
+
+});


### PR DESCRIPTION
### Added two new tests:
1. POST request for /pet enpoint
2. PUT request for /pet endpoint

Created helper methods to store the code for making the request, requests are now reusable and code is cleaner

All tests passing

<img width="342" height="64" alt="image" src="https://github.com/user-attachments/assets/37fd7bb2-b484-4f3d-859e-5fc7e374038b" />
